### PR TITLE
Ibis testing

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install Python Dependencies
       shell: bash
       run: |
-        pip install pytest pandas substrait adbc_driver_manager "ibis-framework[duckdb]==3.2.0" "ibis-substrait==2.21.1" "substrait-validator==0.0.11" 
+        pip install -r test/python/requirements-dev.txt
         pip uninstall protobuf -y
         pip install --no-binary protobuf protobuf
 

--- a/src/to_substrait.cpp
+++ b/src/to_substrait.cpp
@@ -286,7 +286,7 @@ void DuckDBToSubstrait::TransformConstant(Value &dval, substrait::Expression &se
 		TransformEnum(dval, sexpr);
 		break;
 	default:
-		throw InternalException("Transform constant of type %s", duckdb_type.ToString());
+		throw NotImplementedException("Consuming a value of type %s is not supported yet", duckdb_type.ToString());
 	}
 }
 

--- a/test/python/ibis/test_extract_date.py
+++ b/test/python/ibis/test_extract_date.py
@@ -1,0 +1,36 @@
+import duckdb
+import pytest
+
+from ibis_duckdb_tester import CombinedIbisDuckDBTester, SubstraitIbisDuckDBTester
+ibis = pytest.importorskip('ibis')
+
+def extract_component(ibis_db, named_component):
+	tbl = ibis_db.table('tbl')
+	expr = tbl[getattr(tbl.d, named_component)().cast('int64')]
+	return expr
+
+class TestIbisExtractTime(object):
+	def test_extract_combined(self, tmp_path, require):
+		# Create a disk-backed duckdb database
+		db_path = str(tmp_path / 'extract_db')
+
+		tester = CombinedIbisDuckDBTester(db_path, [
+			"""
+				create table tbl(d date)
+			""",
+			"""
+				insert into tbl values ('2021/09/21'::DATE)
+			"""
+		], require)
+
+		date_components = [
+			"day",
+			#"day_of_year",
+			#"epoch_seconds",
+			"month",
+			#"quarter",
+			#"week_of_year",
+			"year"
+		]
+		for component in date_components:
+			tester.test(extract_component, component)

--- a/test/python/ibis/test_extract_time.py
+++ b/test/python/ibis/test_extract_time.py
@@ -1,0 +1,58 @@
+import duckdb
+import pytest
+
+from ibis_duckdb_tester import CombinedIbisDuckDBTester, SubstraitIbisDuckDBTester
+ibis = pytest.importorskip('ibis')
+
+def extract_component(ibis_db, named_component):
+	tbl = ibis_db.table('tbl')
+	expr = tbl[getattr(tbl.d.time(), named_component)().cast('int64')]
+	return expr
+
+class TestIbisExtractTime(object):
+	def test_extract_combined(self, tmp_path, require):
+		# Create a disk-backed duckdb database
+		db_path = str(tmp_path / 'extract_db')
+
+		tester = CombinedIbisDuckDBTester(db_path, [
+			"""
+				create table tbl(d timestamp)
+			""",
+			"""
+				insert into tbl values ('2021/09/21 12:02:21'::TIMESTAMP)
+			"""
+		], require)
+
+		# See issue: https://github.com/ibis-project/ibis/issues/5649
+		# timestamp.time() can't translate to SQL
+		time_components = [
+			#"hour",
+			#"millisecond",
+			#"minute",
+			#"second"
+		]
+		for component in time_components:
+			tester.test(extract_component, component)
+
+	def test_extract_substrait(self, tmp_path, require):
+		# Create a disk-backed duckdb database
+		db_path = str(tmp_path / 'extract_db')
+
+		tester = SubstraitIbisDuckDBTester.create(db_path, [
+			"""
+				create table tbl(d timestamp)
+			""",
+			"""
+				insert into tbl values ('2021/09/21 12:02:21'::TIMESTAMP)
+			"""
+		], require)
+
+		# None of these are mapped yet as of ibis_substrait 2.22.0
+		time_components = [
+			#"hour",
+			#"millisecond",
+			#"minute",
+			#"second"
+		]
+		for component in time_components:
+			tester.test(extract_component, component)

--- a/test/python/ibis/test_extract_timestamp.py
+++ b/test/python/ibis/test_extract_timestamp.py
@@ -1,0 +1,49 @@
+from unicodedata import name
+import duckdb
+import pytest
+
+from ibis_duckdb_tester import CombinedIbisDuckDBTester
+ibis = pytest.importorskip('ibis')
+
+def extract_component(ibis_db, named_component):
+	tbl = ibis_db.table('tbl')
+	expr = tbl[getattr(tbl.date, named_component)().cast('int64')]
+	return expr
+
+
+class TestIbisExtractTimestamp(object):
+	@pytest.mark.parametrize('component', [
+		"day",
+		"day_of_year",
+		"epoch_seconds",
+		"month",
+		"quarter",
+		"week_of_year",
+		"year",
+		"day_of_week", # not sure if this one should be in this list at all
+		"hour",
+		"millisecond",
+		"minute",
+		"second"
+	])
+	def test_extract(self, tmp_path, require, component):
+		# Create a disk-backed duckdb database
+		db_path = str(tmp_path / 'extract_db')
+
+		# NOTE: support for 'extract' seems to be removed for timestamp
+		if component not in [
+			#"day",
+			#"month",
+			#"year"
+		]:
+			pytest.skip(f'{component} not tested (yet)')
+		tester = CombinedIbisDuckDBTester(db_path, [
+			"""
+				create table tbl(date timestamp)
+			""",
+			"""
+				insert into tbl values ('2021/09/21 12:02:21'::TIMESTAMP)
+			"""
+		], require)
+
+		tester.test(extract_component, component)

--- a/test/python/ibis/test_extract_timestamp_tz.py
+++ b/test/python/ibis/test_extract_timestamp_tz.py
@@ -1,0 +1,43 @@
+from unicodedata import name
+import duckdb
+import pytest
+
+from ibis_duckdb_tester import CombinedIbisDuckDBTester
+ibis = pytest.importorskip('ibis')
+
+def extract_component(ibis_db, named_component):
+	tbl = ibis_db.table('tbl')
+	expr = tbl[getattr(tbl.date, named_component)().cast('int64')]
+	return expr
+
+# NOTE: Ibis does not implement 'timestamp_tz' (yet?)
+class TestIbisExtractTimestampTZ(object):
+	def test_extract(self, tmp_path, require):
+		# Create a disk-backed duckdb database
+		db_path = str(tmp_path / 'extract_db')
+
+		tester = CombinedIbisDuckDBTester(db_path, [
+			"""
+				create table tbl(date timestamp)
+			""",
+			"""
+				insert into tbl values ('2021/09/21 12:02:21'::TIMESTAMP)
+			"""
+		], require)
+
+		timestamp_tz_components = [
+			#"day",
+			#"day_of_year",
+			#"epoch_seconds",
+			#"month",
+			#"quarter",
+			#"week_of_year",
+			#"year",
+			#"day_of_week", # not sure if this one should be in this list at all
+			#"hour",
+			#"millisecond",
+			#"minute",
+			#"second"
+		]
+		for component in timestamp_tz_components:
+			tester.test(extract_component, component)

--- a/test/python/ibis_duckdb_tester.py
+++ b/test/python/ibis_duckdb_tester.py
@@ -1,0 +1,87 @@
+import duckdb
+import pytest
+
+SubstraitCompiler = pytest.importorskip('ibis_substrait.compiler.core')
+ibis = pytest.importorskip('ibis')
+
+def initialize_db(path, queries, require):
+	con = require('substrait', path)
+	# Initialize + populate the database
+	for query in queries:
+		con.sql(query)
+	con.close()
+
+class IbisDuckDBTester:
+	def __init__(self, path):
+		self.path = path
+
+	def initialize(self, queries, require):
+		initialize_db(self.path, queries, require)
+		
+	def open(self, require):
+		# Create connections to the db
+		self.con = require('substrait', self.path)
+		self.ibis_con = ibis.connect(f"duckdb://{self.path}")
+
+	def test(self, expression_producer, *args):
+		expr = expression_producer(self.ibis_con, *args)
+		relation = self.generate_relation(expr.unbind())
+
+		# Verify that the expressions produce the same result
+		res = expr.to_pyarrow()
+		duck_res = relation.arrow()
+		assert duck_res == res
+
+class SQLIbisDuckDBTester(IbisDuckDBTester):
+	def create(path, queries, require):
+		self = SQLIbisDuckDBTester(path)
+		self.initialize(queries, require)
+		self.open(require)
+		return self
+
+	def generate_relation(self, expr):
+		# From the ibis expression - generate sql
+		sql_string = str(ibis.to_sql(expr))
+
+		# Then use the sql to generate a relation
+		relation = self.con.sql(sql_string)
+		return relation
+
+	def __init__(self, path):
+		super(SQLIbisDuckDBTester, self).__init__(path)
+
+class SubstraitIbisDuckDBTester(IbisDuckDBTester):
+	def create(path, queries, require):
+		self = SubstraitIbisDuckDBTester(path)
+		self.initialize(queries, require)
+		self.open(require)
+		return self
+
+	def generate_relation(self, expr):
+		compiler = SubstraitCompiler.SubstraitCompiler()
+		from google.protobuf import json_format
+
+		proto = compiler.compile(expr)
+
+		json_plan = json_format.MessageToJson(proto)
+		return self.con.from_substrait_json(json_plan)
+
+	def __init__(self, path):
+		super(SubstraitIbisDuckDBTester, self).__init__(path)
+
+class CombinedIbisDuckDBTester():
+	def __init__(self, path, queries, require):
+		self.path = path
+
+		self.testers = []
+		self.testers += [SQLIbisDuckDBTester(self.path)]
+		self.testers += [SubstraitIbisDuckDBTester(self.path)]
+
+		initialize_db(self.path, queries, require)
+
+		for tester in self.testers:
+			tester.open(require)
+	
+	def test(self, expression_producer, *args):
+		for tester in self.testers:
+			tester.test(expression_producer, *args)

--- a/test/python/ibis_tpch_util.py
+++ b/test/python/ibis_tpch_util.py
@@ -36,7 +36,7 @@ def tpc_h01(con, DELTA=90, DATE="1998-12-01"):
         avg_disc=t.l_discount.mean(),
         count_order=t.count(),
     )
-    q = q.sort_by(["l_returnflag", "l_linestatus"])
+    q = q.order_by(["l_returnflag", "l_linestatus"])
     return q
 
 def tpc_h02(con, REGION="EUROPE", SIZE=25, TYPE="BRASS"):
@@ -86,7 +86,7 @@ def tpc_h02(con, REGION="EUROPE", SIZE=25, TYPE="BRASS"):
         ]
     )
 
-    return q.sort_by(
+    return q.order_by(
         [
             ibis.desc(q.s_acctbal),
             q.n_name,
@@ -107,7 +107,7 @@ def tpc_h03(con, MKTSEGMENT="BUILDING", DATE="1995-03-15"):
     )
     qg = q.group_by([q.l_orderkey, q.o_orderdate, q.o_shippriority])
     q = qg.aggregate(revenue=(q.l_extendedprice * (1 - q.l_discount)).sum())
-    q = q.sort_by([ibis.desc(q.revenue), q.o_orderdate])
+    q = q.order_by([ibis.desc(q.revenue), q.o_orderdate])
     q = q.limit(10)
 
     return q
@@ -127,7 +127,7 @@ def tpc_h04(con, DATE="1993-07-01"):
     )
     q = q.group_by([orders.o_orderpriority])
     q = q.aggregate(order_count=orders.count())
-    q = q.sort_by([orders.o_orderpriority])
+    q = q.order_by([orders.o_orderpriority])
     return q
 
 def tpc_h05(con, NAME="ASIA", DATE="1994-01-01"):
@@ -155,7 +155,7 @@ def tpc_h05(con, NAME="ASIA", DATE="1994-01-01"):
     revexpr = q.l_extendedprice * (1 - q.l_discount)
     gq = q.group_by([q.n_name])
     q = gq.aggregate(revenue=revexpr.sum())
-    q = q.sort_by([ibis.desc(q.revenue)])
+    q = q.order_by([ibis.desc(q.revenue)])
     return q
 
 def tpc_h06(con, DATE="1994-01-01", DISCOUNT=0.06, QUANTITY=24):
@@ -209,7 +209,7 @@ def tpc_h07(con, NATION1="FRANCE", NATION2="GERMANY", DATE="1995-01-01"):
 
     gq = q.group_by(["supp_nation", "cust_nation", "l_year"])
     q = gq.aggregate(revenue=q.volume.sum())
-    q = q.sort_by(["supp_nation", "cust_nation", "l_year"])
+    q = q.order_by(["supp_nation", "cust_nation", "l_year"])
 
     return q
 
@@ -260,7 +260,7 @@ def tpc_h08(
     )
     gq = q.group_by([q.o_year])
     q = gq.aggregate(mkt_share=q.nation_volume.sum() / q.volume.sum())
-    q = q.sort_by([q.o_year])
+    q = q.order_by([q.o_year])
     return q
 
 def tpc_h09(con, COLOR="green"):
@@ -295,7 +295,7 @@ def tpc_h09(con, COLOR="green"):
 
     gq = q.group_by([q.nation, q.o_year])
     q = gq.aggregate(sum_profit=q.amount.sum())
-    q = q.sort_by([q.nation, ibis.desc(q.o_year)])
+    q = q.order_by([q.nation, ibis.desc(q.o_year)])
     return q
 
 def tpc_h10(con, DATE="1993-10-01"):
@@ -329,7 +329,7 @@ def tpc_h10(con, DATE="1993-10-01"):
     )
     q = gq.aggregate(revenue=(q.l_extendedprice * (1 - q.l_discount)).sum())
 
-    q = q.sort_by(ibis.desc(q.revenue))
+    q = q.order_by(ibis.desc(q.revenue))
     return q.limit(20)
 
 def tpc_h11(con, NATION="GERMANY", FRACTION=0.0001):
@@ -352,7 +352,7 @@ def tpc_h11(con, NATION="GERMANY", FRACTION=0.0001):
     gq = q.group_by([q.ps_partkey])
     q = gq.aggregate(value=(q.ps_supplycost * q.ps_availqty).sum())
     q = q.filter([q.value > innerq.total * FRACTION])
-    q = q.sort_by(ibis.desc(q.value))
+    q = q.order_by(ibis.desc(q.value))
     return q
 
 def tpc_h12(con, SHIPMODE1="MAIL", SHIPMODE2="SHIP", DATE="1994-01-01"):
@@ -393,7 +393,7 @@ def tpc_h12(con, SHIPMODE1="MAIL", SHIPMODE2="SHIP", DATE="1994-01-01"):
             .end()
         ).sum(),
     )
-    q = q.sort_by(q.l_shipmode)
+    q = q.order_by(q.l_shipmode)
 
     return q
 
@@ -416,7 +416,7 @@ def tpc_h13(con, WORD1="special", WORD2="requests"):
     gq = innerq.group_by([innerq.c_count])
     q = gq.aggregate(custdist=innerq.count())
 
-    q = q.sort_by([ibis.desc(q.custdist), ibis.desc(q.c_count)])
+    q = q.order_by([ibis.desc(q.custdist), ibis.desc(q.c_count)])
     return q
 
 def tpc_h14(con, DATE="1995-09-01"):
@@ -454,7 +454,7 @@ def tpc_h15(con, DATE="1996-01-01"):
 
     q = supplier.join(qrev, supplier.s_suppkey == qrev.l_suppkey)
     q = q.filter([q.total_revenue == qrev.total_revenue.max()])
-    q = q.sort_by([q.s_suppkey])
+    q = q.order_by([q.s_suppkey])
     q = q[q.s_suppkey, q.s_name, q.s_address, q.s_phone, q.total_revenue]
     return q
 
@@ -487,9 +487,9 @@ def tpc_h16(
             ),
         ]
     )
-    gq = q.groupby([q.p_brand, q.p_type, q.p_size])
+    gq = q.group_by([q.p_brand, q.p_type, q.p_size])
     q = gq.aggregate(supplier_cnt=q.ps_suppkey.nunique())
-    q = q.sort_by([ibis.desc(q.supplier_cnt), q.p_brand, q.p_type, q.p_size])
+    q = q.order_by([ibis.desc(q.supplier_cnt), q.p_brand, q.p_type, q.p_size])
     return q
 
 def tpc_h17(con, BRAND="Brand#23", CONTAINER="MED BOX"):
@@ -526,7 +526,7 @@ def tpc_h18(con, QUANTITY=300):
     orders = con.table("orders")
     lineitem = con.table("lineitem")
 
-    subgq = lineitem.groupby([lineitem.l_orderkey])
+    subgq = lineitem.group_by([lineitem.l_orderkey])
     subq = subgq.aggregate(qty_sum=lineitem.l_quantity.sum())
     subq = subq.filter([subq.qty_sum > QUANTITY])
 
@@ -535,9 +535,9 @@ def tpc_h18(con, QUANTITY=300):
     q = q.join(lineitem, orders.o_orderkey == lineitem.l_orderkey)
     q = q.filter([q.o_orderkey.isin(subq.l_orderkey)])
 
-    gq = q.groupby([q.c_name, q.c_custkey, q.o_orderkey, q.o_orderdate, q.o_totalprice])
+    gq = q.group_by([q.c_name, q.c_custkey, q.o_orderkey, q.o_orderdate, q.o_totalprice])
     q = gq.aggregate(sum_qty=q.l_quantity.sum())
-    q = q.sort_by([ibis.desc(q.o_totalprice), q.o_orderdate])
+    q = q.order_by([ibis.desc(q.o_totalprice), q.o_orderdate])
     return q.limit(100)
 
 def tpc_h19(
@@ -630,7 +630,7 @@ def tpc_h20(con, COLOR="forest", DATE="1994-01-01", NATION="CANADA"):
 
     q1 = q1[q1.s_name, q1.s_address]
 
-    return q1.sort_by(q1.s_name)
+    return q1.order_by(q1.s_name)
 
 def tpc_h21(con, NATION="SAUDI ARABIA"):
     """Suppliers Who Kept Orders Waiting Query (Q21)
@@ -676,7 +676,7 @@ def tpc_h21(con, NATION="SAUDI ARABIA"):
 
     gq = q.group_by([q.s_name])
     q = gq.aggregate(numwait=q.count())
-    q = q.sort_by([ibis.desc(q.numwait), q.s_name])
+    q = q.order_by([ibis.desc(q.numwait), q.s_name])
     return q.limit(100)
 
 def tpc_h22(con, COUNTRY_CODES=("13", "31", "23", "29", "30", "18", "17")):
@@ -709,7 +709,7 @@ def tpc_h22(con, COUNTRY_CODES=("13", "31", "23", "29", "30", "18", "17")):
     gq = custsale.group_by(custsale.cntrycode)
     outerq = gq.aggregate(numcust=custsale.count(), totacctbal=custsale.c_acctbal.sum())
 
-    return outerq.sort_by(outerq.cntrycode)
+    return outerq.order_by(outerq.cntrycode)
 
 def invalid_query(con):
 	assert 0

--- a/test/python/requirements-dev.txt
+++ b/test/python/requirements-dev.txt
@@ -1,0 +1,7 @@
+pytest
+pandas
+pyarrow
+ibis-framework==8.0.0
+ibis-substrait==3.2.1
+substrait-validator==0.0.11
+duckdb-engine==0.9.2

--- a/test/python/test_ibis_duckdb_tpch.py
+++ b/test/python/test_ibis_duckdb_tpch.py
@@ -9,7 +9,7 @@ get_tpch_query = pytest.importorskip('ibis_tpch_util')
 pandas = pytest.importorskip("pandas")
 
 def unbound_from_duckdb(table):  # noqa: D103
-    return ibis.table(list(zip(table.columns, map(parse_type.parse, [str(x) for x in table.dtypes]))), name=table.alias)
+    return ibis.table(list(zip(table.columns, map(parse_type.DuckDBType.from_string, [str(x) for x in table.dtypes]))), name=table.alias)
 
 class TPCHBackend(BaseBackend.BaseBackend):  # noqa: D101
     def __init__(self,duck_con,  scale_factor=0.1):  # noqa: D107
@@ -54,6 +54,18 @@ class TPCHBackend(BaseBackend.BaseBackend):  # noqa: D101
     def list_tables(self):  # noqa: D102
         ...
 
+    def create_table(self):  # noqa: D102
+        ...
+
+    def create_view(self):  # noqa: D102
+        ...
+
+    def drop_table(self):  # noqa: D102
+        ...
+
+    def drop_view(self):  # noqa: D102
+        ...
+
     def version(self):  # noqa: D102
         return "awesome"
 
@@ -90,83 +102,79 @@ def run_query(require, query_number):
 def test_query_substrait_ibis_to_duck_01(require):
     run_query(require,1)
     
-@pytest.mark.skip(reason="Ibis Compilation: 'TableArrayView")
+@pytest.mark.skip(reason="Ibis Compilation: Subqueries are unsupported as function inputs")
 def test_query_substrait_ibis_to_duck_02(require):
     run_query(require,2)
 
-@pytest.mark.skip(reason="Attempting to fetch from an unsuccessful query result")
 def test_query_substrait_ibis_to_duck_03(require):
     run_query(require,3)
 
-@pytest.mark.skip(reason="Ibis Compilation: 'ExistsSubquery'")
+@pytest.mark.skip(reason="DuckDB Consumption: INTERNAL Error: Unsupported expression type 12")
 def test_query_substrait_ibis_to_duck_04(require):
     run_query(require,4)
 
-@pytest.mark.skip(reason="Attempting to fetch from an unsuccessful query result")
 def test_query_substrait_ibis_to_duck_05(require):
     run_query(require,5)
     
 def test_query_substrait_ibis_to_duck_06(require):
     run_query(require,6)
 
-@pytest.mark.skip(reason="Ibis Compilation: (SelfReference(table=UnboundTable: nation")
+@pytest.mark.skip(reason="Attributes of column l_year are different")
 def test_query_substrait_ibis_to_duck_07(require):
     run_query(require,7)
 
-@pytest.mark.skip(reason="Ibis Compilation: (SelfReference(table=UnboundTable: nation")
+@pytest.mark.skip(reason="Ibis Compilation: Parameter to MergeFrom() must be instance of same class")
 def test_query_substrait_ibis_to_duck_08(require):
     run_query(require,8)
 
-@pytest.mark.skip(reason="DuckDB Consumption: Unsupported expression type 10")
+@pytest.mark.skip(reason="Attributes of column o_year are different")
 def test_query_substrait_ibis_to_duck_09(require):
     run_query(require,9)
-
-@pytest.mark.skip(reason="Attempting to fetch from an unsuccessful query result")    
+   
 def test_query_substrait_ibis_to_duck_10(require):
     run_query(require,10)
 
-@pytest.mark.skip(reason="Results do not match")
+@pytest.mark.skip(reason="DataFrame are different")
 def test_query_substrait_ibis_to_duck_11(require):
     run_query(require,11)
 
 def test_query_substrait_ibis_to_duck_12(require):
     run_query(require,12)
 
-@pytest.mark.skip(reason="DuckDB Consumption: Catalog Error: Scalar Function with name not does not exist!")
 def test_query_substrait_ibis_to_duck_13(require):
     run_query(require,13)
     
-@pytest.mark.skip(reason="Ibis Compilation: Parameter to MergeFrom() must be instance of same class: expected substrait.Expression got substrait")
+@pytest.mark.skip(reason="Ibis Compilation: Parameter to MergeFrom() must be instance of same class")
 def test_query_substrait_ibis_to_duck_14(require):
     run_query(require,14)
 
-@pytest.mark.skip(reason="Ibis Compilation: non-empty child_rel_field_offsets passed in to selection translation rule")
+@pytest.mark.skip(reason="Ibis Compilation: Subqueries are unsupported as function inputs")
 def test_query_substrait_ibis_to_duck_15(require):
     run_query(require,15)
 
-@pytest.mark.skip(reason="Ibis Compilation: 'IntegerColumn' object is not iterable")
+@pytest.mark.skip(reason="Ibis Compilation: No available extension defined for function name countdistinct")
 def test_query_substrait_ibis_to_duck_16(require):
     run_query(require,16)
 
-@pytest.mark.skip(reason="Ibis Compilation: <class 'ibis.expr.operations.relations.Aggregation'>")
+@pytest.mark.skip(reason="Ibis Compilation: Subqueries are unsupported as function inputs")
 def test_query_substrait_ibis_to_duck_17(require):
     run_query(require,17)
     
-@pytest.mark.skip(reason="Ibis Compilation: 'IntegerColumn' object is not iterable")
+@pytest.mark.skip(reason="DataFrame are different")
 def test_query_substrait_ibis_to_duck_18(require):
     run_query(require,18)
 
 def test_query_substrait_ibis_to_duck_19(require):
     run_query(require,19)
 
-@pytest.mark.skip(reason="Ibis Compilation: 'IntegerColumn' object is not iterable")
+@pytest.mark.skip(reason="Invalid Input Error: Attempting to fetch from an unsuccessful query result")
 def test_query_substrait_ibis_to_duck_20(require):
     run_query(require,20)
 
-@pytest.mark.skip(reason="Ibis Compilation: 'ExistsSubquery'")
+@pytest.mark.skip(reason="Unsupported expression type 12")
 def test_query_substrait_ibis_to_duck_21(require):
     run_query(require,21)
 
-@pytest.mark.skip(reason="Ibis Compilation: 'NotExistsSubquery'")
+@pytest.mark.skip(reason="Unsupported expression type 12")
 def test_query_substrait_ibis_to_duck_22(require):
     run_query(require,22)


### PR DESCRIPTION
This PR hijacks https://github.com/duckdb/substrait/pull/45 to improve testing with ibis.

Also bumps the `ibis-framework` version to `8.0.0` and `ibis-substrait` version to `3.2.1`