### PR TITLE
Nightly Distribution

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -1,0 +1,39 @@
+#
+# This workflow calls the main distribution pipeline from DuckDB to build, test and (optionally) release the extension
+#
+name: Stable Extension Distribution Pipeline
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.md'
+      - 'doc/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.md'
+      - 'doc/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  duckdb-stable-build:
+    name: Build extension binaries
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.0
+    with:
+      duckdb_version: v1.1.0
+      extension_name: substrait
+
+  duckdb-stable-deploy:
+    name: Deploy extension binaries
+    needs: duckdb-stable-build
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.1.0
+    secrets: inherit
+    with:
+      duckdb_version: v1.1.0
+      extension_name: substrait

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -27,6 +27,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.1.0
     with:
       duckdb_version: v1.1.0
+      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_rtools"
       extension_name: substrait
 
   duckdb-stable-deploy:
@@ -36,4 +37,5 @@ jobs:
     secrets: inherit
     with:
       duckdb_version: v1.1.0
+      exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64;windows_amd64_rtools"
       extension_name: substrait


### PR DESCRIPTION
This will allow for the substrait extension to be built and distributed for every push on `main`.

It currently is tagged with DuckDB v1.1, and eventually we should also allow it for DuckDB `main`.

Using DuckDB v1.1, you should be able to get the substrait `main` branch extension with:

```sql
FORCE INSTALL substrait FROM core_nightly
```